### PR TITLE
feat: add started_at and queued_at to Encoder

### DIFF
--- a/lib/roger/job.ex
+++ b/lib/roger/job.ex
@@ -40,7 +40,7 @@ defmodule Roger.Job do
 
   @type t :: %__MODULE__{}
 
-  @derive {Poison.Encoder, only: ~w(id module args queue_key execution_key retry_count)a}
+  @derive {Poison.Encoder, only: ~w(id module args queue_key execution_key retry_count started_at queued_at)a}
   defstruct id: nil, module: nil, args: nil, queue_key: nil, execution_key: nil, retry_count: 0, started_at: 0, queued_at: 0
 
   alias Roger.{Queue, Partition.Global, Job}


### PR DESCRIPTION
Two variables that allow calculate running time and queued time